### PR TITLE
Make win-tab switching show a list of currently open windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 orbclient = "0.2"
 orbimage = "0.1"
 orbfont = "0.1"
-lazy_static = "*"
 redox_syscall = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,6 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 [dependencies]
 orbclient = "0.2"
 orbimage = "0.1"
+orbfont = "0.1"
+lazy_static = "*"
 redox_syscall = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@
 
 extern crate orbclient;
 extern crate orbimage;
+extern crate orbfont;
+#[macro_use]
+extern crate lazy_static;
 extern crate syscall;
 
 use orbclient::{Color, Event};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@
 extern crate orbclient;
 extern crate orbimage;
 extern crate orbfont;
-#[macro_use]
-extern crate lazy_static;
 extern crate syscall;
 
 use orbclient::{Color, Event};

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -13,10 +13,6 @@ use rect::Rect;
 use socket::Socket;
 use window::Window;
 
-lazy_static! {
-    static ref FONT: orbfont::Font = orbfont::Font::find(None, None, None).unwrap();
-}
-
 fn schedule(redraws: &mut Vec<Rect>, request: Rect) {
     let mut push = true;
     for mut rect in redraws.iter_mut() {
@@ -51,7 +47,8 @@ pub struct OrbitalScheme {
     order: VecDeque<usize>,
     pub windows: BTreeMap<usize, Window>,
     redraws: Vec<Rect>,
-    pub todo: Vec<Packet>
+    pub todo: Vec<Packet>,
+    font: orbfont::Font
 }
 
 impl OrbitalScheme {
@@ -76,7 +73,8 @@ impl OrbitalScheme {
             order: VecDeque::new(),
             windows: BTreeMap::new(),
             redraws: vec![Rect::new(0, 0, width, height)],
-            todo: Vec::new()
+            todo: Vec::new(),
+            font: orbfont::Font::find(None, None, None).unwrap() 
         }
     }
 
@@ -169,9 +167,9 @@ impl OrbitalScheme {
         for id in self.order.iter() {
             if let Some(window) = self.windows.get(id) {
                 if window.title.is_empty() {
-                    rendered_text.push(FONT.render(&format!("[unnamed #{}]", id), 12.0));
+                    rendered_text.push(self.font.render(&format!("[unnamed #{}]", id), 12.0));
                 } else {
-                    rendered_text.push(FONT.render(&format!("{}", &window.title), 12.0));
+                    rendered_text.push(self.font.render(&format!("{}", &window.title), 12.0));
                 }
             }
         }
@@ -192,7 +190,7 @@ impl OrbitalScheme {
 
     pub fn event(&mut self, event: Event){
         if event.code == EVENT_KEY {
-            if event.b == 0x5B {
+            if event.b == 0x38 {
                 self.win_key = event.c > 0;
                 // If the win key was released, stop drawing the win-tab window switcher
                 if !self.win_key {

--- a/src/window.rs
+++ b/src/window.rs
@@ -17,7 +17,7 @@ pub struct Window {
     pub async: bool,
     image: Image,
     char_image: Image,
-    title: String,
+    pub title: String,
     pub events: VecDeque<Event>,
 }
 


### PR DESCRIPTION
How it looks: https://gfycat.com/UnhealthyDistantDesertpupfish

`OrbitalScheme` has an added variable, `win_tabbing`. When the user presses super-tab it's set to true. This makes each call to `draw()` call `draw_window_list()`. When super is released, `win_tabbing` is set false, window list isn't drawn anymore.