### PR TITLE
Make Orbital Login Window Unclosable (scheme, window)

### DIFF
--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -625,7 +625,7 @@ impl OrbitalScheme {
                             //TODO: Trigger max and exit on release
                             if event.left && ! self.cursor_left  {
                                 focus = i;
-                                if window.max_contains(self.cursor_x, self.cursor_y) {
+                                if (window.max_contains(self.cursor_x, self.cursor_y)) && (window.resizable) {
                                     let max_restore_opt = window.max_restore.take();
 
                                     if max_restore_opt.is_none() {
@@ -657,13 +657,12 @@ impl OrbitalScheme {
                                     } else {
                                         (self.image.width(), self.image.height() - window.y)
                                     };
-
                                     let resize_event = ResizeEvent {
                                         width: width as u32,
                                         height: height as u32,
                                     }.to_event();
                                     window.event(resize_event);
-                                } else if window.close_contains(self.cursor_x, self.cursor_y) {
+                                } else if (window.close_contains(self.cursor_x, self.cursor_y)) && (window.exit) {
                                     window.event(QuitEvent.to_event());
                                 } else {
                                     self.dragging = DragMode::Title(id, self.cursor_x, self.cursor_y);
@@ -773,10 +772,12 @@ impl SchemeMut for OrbitalScheme {
 
         let mut async = false;
         let mut resizable = false;
+        let mut exit = true;
         for flag in flags.chars() {
             match flag {
                 'a' => async = true,
                 'r' => resizable = true,
+                'e' => exit = false,
                 _ => ()
             }
         }
@@ -811,7 +812,7 @@ impl SchemeMut for OrbitalScheme {
             }
         }
 
-        let window = Window::new(x, y, width, height, title, async, resizable, &self.font);
+        let window = Window::new(x, y, width, height, title, async, resizable, exit, &self.font);
         schedule(&mut self.redraws, window.title_rect());
         schedule(&mut self.redraws, window.rect());
         self.order.push_front(id);

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -662,7 +662,7 @@ impl OrbitalScheme {
                                         height: height as u32,
                                     }.to_event();
                                     window.event(resize_event);
-                                } else if (window.close_contains(self.cursor_x, self.cursor_y)) && (window.exit) {
+                                } else if (window.close_contains(self.cursor_x, self.cursor_y)) && (!window.unclosable) {
                                     window.event(QuitEvent.to_event());
                                 } else {
                                     self.dragging = DragMode::Title(id, self.cursor_x, self.cursor_y);
@@ -772,12 +772,12 @@ impl SchemeMut for OrbitalScheme {
 
         let mut async = false;
         let mut resizable = false;
-        let mut exit = true;
+        let mut unclosable= false;
         for flag in flags.chars() {
             match flag {
                 'a' => async = true,
                 'r' => resizable = true,
-                'e' => exit = false,
+                'u' => unclosable = true,
                 _ => ()
             }
         }
@@ -812,7 +812,7 @@ impl SchemeMut for OrbitalScheme {
             }
         }
 
-        let window = Window::new(x, y, width, height, title, async, resizable, exit, &self.font);
+        let window = Window::new(x, y, width, height, title, async, resizable, unclosable, &self.font);
         schedule(&mut self.redraws, window.title_rect());
         schedule(&mut self.redraws, window.rect());
         self.order.push_front(id);

--- a/src/window.rs
+++ b/src/window.rs
@@ -17,6 +17,7 @@ pub struct Window {
     pub y: i32,
     pub async: bool,
     pub resizable: bool,
+    pub exit: bool,
     pub title: String,
     pub max_restore: Option<Rect>,
     image: Image,
@@ -26,12 +27,13 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: String, async: bool, resizable: bool, font: &Font) -> Window {
+    pub fn new(x: i32, y: i32, w: i32, h: i32, title: String, async: bool, resizable: bool, exit: bool, font: &Font) -> Window {
         let mut window = Window {
             x: x,
             y: y,
             async: async,
             resizable: resizable,
+            exit: exit,
             title: title,
             max_restore: None,
             image: Image::new(w, h),
@@ -127,12 +129,14 @@ impl Window {
                 }
             }
 
-            x = max(self.x + 6, self.x + self.width() - 18);
-            if x + 18 <= self.x + self.width() {
-                let image_rect = Rect::new(x, title_rect.top() + 7, window_close.width(), window_close.height());
-                let image_intersect = rect.intersection(&image_rect);
-                if ! image_intersect.is_empty() {
-                    image.roi(&image_intersect).blend(&window_close.roi(&image_intersect.offset(-image_rect.left(), -image_rect.top())));
+            if self.exit {
+                x = max(self.x + 6, self.x + self.width() - 18);
+                if x + 18 <= self.x + self.width() {
+                    let image_rect = Rect::new(x, title_rect.top() + 7, window_close.width(), window_close.height());
+                    let image_intersect = rect.intersection(&image_rect);
+                    if ! image_intersect.is_empty() {
+                        image.roi(&image_intersect).blend(&window_close.roi(&image_intersect.offset(-image_rect.left(), -image_rect.top())));
+                    }
                 }
             }
         }
@@ -178,9 +182,10 @@ impl Window {
     pub fn path(&self, buf: &mut [u8]) -> Result<usize> {
         let mut i = 0;
         let path_str = format!(
-            "orbital:{}{}/{}/{}/{}/{}/{}",
+            "orbital:{}{}{}/{}/{}/{}/{}/{}",
             if self.async { "a" } else { "" },
             if self.resizable { "r" } else { "" },
+            if self.exit { "e" } else { "" },
             self.x, self.y, self.width(), self.height(), self.title
         );
         let path = path_str.as_bytes();

--- a/src/window.rs
+++ b/src/window.rs
@@ -17,7 +17,7 @@ pub struct Window {
     pub y: i32,
     pub async: bool,
     pub resizable: bool,
-    pub exit: bool,
+    pub unclosable: bool,
     pub title: String,
     pub max_restore: Option<Rect>,
     image: Image,
@@ -27,13 +27,13 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: String, async: bool, resizable: bool, exit: bool, font: &Font) -> Window {
+    pub fn new(x: i32, y: i32, w: i32, h: i32, title: String, async: bool, resizable: bool, unclosable: bool, font: &Font) -> Window {
         let mut window = Window {
             x: x,
             y: y,
             async: async,
             resizable: resizable,
-            exit: exit,
+            unclosable: unclosable,
             title: title,
             max_restore: None,
             image: Image::new(w, h),
@@ -129,7 +129,7 @@ impl Window {
                 }
             }
 
-            if self.exit {
+            if !self.unclosable {
                 x = max(self.x + 6, self.x + self.width() - 18);
                 if x + 18 <= self.x + self.width() {
                     let image_rect = Rect::new(x, title_rect.top() + 7, window_close.width(), window_close.height());
@@ -185,7 +185,7 @@ impl Window {
             "orbital:{}{}{}/{}/{}/{}/{}/{}",
             if self.async { "a" } else { "" },
             if self.resizable { "r" } else { "" },
-            if self.exit { "e" } else { "" },
+            if self.unclosable { "u" } else { "" },
             self.x, self.y, self.width(), self.height(), self.title
         );
         let path = path_str.as_bytes();


### PR DESCRIPTION
scheme:
added exit to list of parameters in calls to Window::new in SchemeMut.
Added conditions for handling window.resizable and window.exit events in
OrbitalScheme. If exit is false, modified to write 'e' to file in
SchemeMut

window:
Added exit bool to Window struct, as well as exit in parameters of
function new. Added handling to not render Exit if Exit flag is passed.
modified to write "e" to file if Exit flag is false


Other pull requests which fix this issue but in different git submodules are under the same branch name (make-orbital-login-unclosable)

this also fixes the issue with the Resizable event firing even when the window is not supposed to be resizable. (Issue #11 )