### PR TITLE
Use toml and serde for config files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,10 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 
 [dependencies]
 orbclient = "0.3"
-orbimage = "0.1"
 orbfont = "0.1"
-resize = "0.2"
+orbimage = "0.1"
 redox_syscall = "0.1"
+resize = "0.2"
+serde = "0.9"
+serde_derive = "0.9"
+toml = "0.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,9 @@
 use std::fs::File;
 use std::io::Read;
+use toml;
 
+#[derive(Default, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub background: Vec<String>,
     pub background_mode: String,
@@ -26,57 +29,12 @@ impl Config {
             Err(err) => println!("orbital: failed to open config '{}': {}", path, err)
         }
 
-        Config::from_str(&string)
-    }
-
-    pub fn from_str(string: &str) -> Config {
-        let mut config = Config {
-            background: Vec::new(),
-            background_mode: String::new(),
-            cursor: String::new(),
-            bottom_right_corner: String::new(),
-            bottom_side: String::new(),
-            right_side: String::new(),
-            window_max: String::new(),
-            window_max_unfocused: String::new(),
-            window_close: String::new(),
-            window_close_unfocused: String::new(),
-        };
-
-        for line_original in string.lines() {
-            let line = line_original.trim();
-            if line.starts_with("background=") {
-                config.background.push(line[11..].to_string());
-            }
-            if line.starts_with("background_mode=") {
-                config.background_mode = line[16..].to_string();
-            }
-            if line.starts_with("cursor=") {
-                config.cursor = line[7..].to_string();
-            }
-            if line.starts_with("bottom_right_corner=") {
-                config.bottom_right_corner = line[20..].to_string();
-            }
-            if line.starts_with("bottom_side=") {
-                config.bottom_side = line[12..].to_string();
-            }
-            if line.starts_with("right_side=") {
-                config.right_side = line[11..].to_string();
-            }
-            if line.starts_with("window_max=") {
-                config.window_max = line[11..].to_string();
-            }
-            if line.starts_with("window_max_unfocused=") {
-                config.window_max_unfocused = line[21..].to_string();
-            }
-            if line.starts_with("window_close=") {
-                config.window_close = line[13..].to_string();
-            }
-            if line.starts_with("window_close_unfocused=") {
-                config.window_close_unfocused = line[23..].to_string();
+        match toml::from_str(&string) {
+            Ok(config) => config,
+            Err(err) => {
+                println!("orbital: failed to parse config '{}': {}", path, err);
+                Config::default()
             }
         }
-
-        config
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ extern crate orbclient;
 extern crate orbimage;
 extern crate orbfont;
 extern crate resize;
+#[macro_use]
+extern crate serde_derive;
 extern crate syscall;
+extern crate toml;
 
 use orbclient::Event;
 use std::{env, mem, str, thread};
@@ -163,7 +166,7 @@ fn main() {
 
                     println!("orbital: found display {}x{}", width, height);
 
-                    let config = Config::from_path("/ui/orbital.conf");
+                    let config = Config::from_path("/ui/orbital.toml");
 
                     let scheme = Arc::new(Mutex::new(OrbitalScheme::new(width, height, display.as_raw_fd(), &config)));
 


### PR DESCRIPTION
Reasons for this pull request: Using a serde is less error-prone than manually deserializing the config file. And toml makes the config file easier to parse for other userspace applications.